### PR TITLE
Changed `ReadableStreamReadResultInProcess.Value` to return `IJSInProcessObjectReference` instead of `IJSObjectReference`.

### DIFF
--- a/samples/KristofferStrube.Blazor.Streams.WasmExample/Pages/Index.razor
+++ b/samples/KristofferStrube.Blazor.Streams.WasmExample/Pages/Index.razor
@@ -1,4 +1,5 @@
 ﻿@page "/"
+@using KristofferStrube.Blazor.WebIDL
 @inject IJSInProcessRuntime JSRuntime
 
 <PageTitle>Streams - Index</PageTitle>
@@ -15,7 +16,7 @@ Using the reader we read the chunks until there are no more.
 }
 
 @code {
-    private List<int> chunkSizes = new();
+    private List<long> chunkSizes = new();
     private int dataSize = 1000 * 1024;
 
     protected override async Task OnInitializedAsync()
@@ -28,7 +29,12 @@ Using the reader we read the chunks until there are no more.
         ReadableStreamReadResultInProcess read = await readableStreamReader.ReadAsync();
         while (!read.Done)
         {
-            var length = await JSRuntime.InvokeAsync<int>("getAttribute", read.Value, "length");
+            await using Uint8ArrayInProcess chunk = await Uint8ArrayInProcess.CreateAsync(
+                JSRuntime,
+                read.Value,
+                new() { DisposesJSReference = true }
+            );
+            var length = chunk.Length;
             chunkSizes.Add(length);
             await Task.Delay(100);
             await read.DisposeAsync();

--- a/src/KristofferStrube.Blazor.Streams/ReadableStream/ReadableStreamReadResult.InProcess.cs
+++ b/src/KristofferStrube.Blazor.Streams/ReadableStream/ReadableStreamReadResult.InProcess.cs
@@ -35,8 +35,8 @@ public class ReadableStreamReadResultInProcess : ReadableStreamReadResult
     /// <summary>
     /// A JS Reference to a chunk of data.
     /// </summary>
-    /// <returns>A <see cref="IJSObjectReference"/> to a value which can be of <c>any</c> type.</returns>
-    public IJSObjectReference Value => inProcessHelper.Invoke<IJSObjectReference>("getAttribute", JSReference, "value");
+    /// <returns>An <see cref="IJSInProcessObjectReference"/> to a value which can be of <c>any</c> type.</returns>
+    public IJSInProcessObjectReference Value => inProcessHelper.Invoke<IJSInProcessObjectReference>("getAttribute", JSReference, "value");
 
     /// <summary>
     /// Indicates whether this is the last read which means that <see cref="Value"/> will be <c>undefined</c>.


### PR DESCRIPTION
Fixes #14 