### PR TITLE
Ensure that streams dispose of reference.

### DIFF
--- a/src/KristofferStrube.Blazor.Streams/BaseJSStreamableWrapper.cs
+++ b/src/KristofferStrube.Blazor.Streams/BaseJSStreamableWrapper.cs
@@ -25,12 +25,13 @@ public abstract class BaseJSStreamableWrapper : Stream, IAsyncDisposable, IJSWra
     /// <inheritdoc cref="IJSCreatable{T}.CreateAsync(IJSRuntime, IJSObjectReference, CreationOptions)"/>
     protected internal BaseJSStreamableWrapper(IJSRuntime jSRuntime, IJSObjectReference jSReference, CreationOptions options)
     {
-        helperTask = new(() => jSRuntime.GetHelperAsync());
+        helperTask = new(jSRuntime.GetHelperAsync);
         JSRuntime = jSRuntime;
         JSReference = jSReference;
         DisposesJSReference = options.DisposesJSReference;
     }
 
+    /// <inheritdoc/>
     public override async ValueTask DisposeAsync()
     {
         await base.DisposeAsync();
@@ -39,6 +40,7 @@ public abstract class BaseJSStreamableWrapper : Stream, IAsyncDisposable, IJSWra
             IJSObjectReference module = await helperTask.Value;
             await module.DisposeAsync();
         }
+        await IJSWrapper.DisposeJSReference(this);
         GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
I found out that the stream types did not dispose of their JS references.